### PR TITLE
Check the artifact cache if resource artifact status is set

### DIFF
--- a/controllers/mavenartifact_controller.go
+++ b/controllers/mavenartifact_controller.go
@@ -321,8 +321,8 @@ func MavenArtifactDownloadSyncReconciler(httpRootDir, httpHost string, now func(
 				return err
 			}
 
-			// Compare checksum with cache
-			if cache != nil {
+			// Compare checksum with cache if the resource status.artifact is set
+			if cache != nil && parent.Status.Artifact != nil {
 				if cache.checksum == remoteChecksum && cache.source == artifactInfo.ArtifactDownloadURL {
 					log.Info("download skipped", "checksum matched on disc", cache.checksum, "checksum from remote repository", remoteChecksum)
 					return nil


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

The `MavenArtifact` API status condition was set incorrectly during the artifact cache check. This PR adds a check for the resource `status.artifact` while verifying the artifact cache. 
### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #97 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Unit Test
- Manual Test 

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

```sh
NAME                       ARTIFACT   URL                                                                                                                                                                                    READY   REASON   AGE
mavenartifact-sample-101   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-101/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-102   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-102/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-103   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-103/24172368644c81e304f787bcae58f9653cb2aa7b.tar.gz   True    Ready    12h
mavenartifact-sample-104   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-104/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-105   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-105/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-106   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-106/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-107   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-107/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-108   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-108/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-109   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-109/24172368644c81e304f787bcae58f9653cb2aa7b.tar.gz   True    Ready    12h
mavenartifact-sample-110   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-110/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-111   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-111/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-112   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-112/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-113   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-113/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-114   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-114/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-115   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-115/24172368644c81e304f787bcae58f9653cb2aa7b.tar.gz   True    Ready    12h
mavenartifact-sample-116   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-116/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-117   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-117/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-118   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-118/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-119   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-119/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-120   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-120/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-121   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-121/24172368644c81e304f787bcae58f9653cb2aa7b.tar.gz   True    Ready    12h
mavenartifact-sample-122   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-122/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-123   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-123/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-124   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-124/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-125   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-125/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-126   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-126/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-127   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-127/24172368644c81e304f787bcae58f9653cb2aa7b.tar.gz   True    Ready    12h
mavenartifact-sample-128   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-128/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-129   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-129/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-130   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-130/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-131   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-131/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-132   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-132/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-133   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-133/24172368644c81e304f787bcae58f9653cb2aa7b.tar.gz   True    Ready    12h
mavenartifact-sample-134   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-134/ae1fe052f8788a7547b88b8f4d42f499c99788fa.tar.gz   True    Ready    12h
mavenartifact-sample-135   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-135/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
mavenartifact-sample-136   demo       http://source-controller-manager-artifact-service.source-system.svc.cluster.local./mavenartifact/maven-test/mavenartifact-sample-136/1ae5966200ecc832b27d037fc2fbf70a4085da7f.tar.gz   True    Ready    12h
```
<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

