### PR TITLE
chore: group dependabot dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    k8s-dependencies:
+      patterns:
+      - "k8s.io*"
 - package-ecosystem: gomod
   directory: "/hack"
   schedule:


### PR DESCRIPTION
This is an attempt to reduce the number of PRs that dependabot will generate against this repo.