### PR TITLE
Fix index-out-of-range panic on malformed image digest reference

### DIFF
--- a/controllers/imagerepository_controller.go
+++ b/controllers/imagerepository_controller.go
@@ -207,7 +207,14 @@ func ImageRepositoryPullImageSyncReconciler(httpRootDir, httpHost string, now fu
 			if imageRef == "" {
 				return nil
 			}
-			artifactTgzFilename := fmt.Sprintf("%s.tar.gz", strings.Split(imageRef, "@sha256:")[1])
+			digest, err := name.NewDigest(imageRef, name.WeakValidation)
+			if err != nil {
+				log.Error(err, "unable to parse image digest", "image", imageRef)
+				parent.ManageConditions().MarkFalse(sourcev1alpha1.ImageRepositoryConditionImageResolved, "MalformedDigest", "Image reference %q is not a valid digest: %s", imageRef, err)
+				return nil
+			}
+			_, digestHex, _ := strings.Cut(digest.DigestStr(), ":")
+			artifactTgzFilename := fmt.Sprintf("%s.tar.gz", digestHex)
 			if !path.IsAbs(httpRootDir) {
 				httpRootDir = path.Join(httpRootDir)
 			}

--- a/controllers/imagerepository_controller_test.go
+++ b/controllers/imagerepository_controller_test.go
@@ -874,6 +874,27 @@ func TestImageRepositoryPullImageSyncReconciler(t *testing.T) {
 				SpecDie(func(d *diesourcev1alpha1.ImageRepositorySpecDie) {
 					d.Image(image)
 				}).DieReleasePtr(),
+		},
+		"malformed digest": {
+			Resource: parent.
+				SpecDie(func(d *diesourcev1alpha1.ImageRepositorySpecDie) {
+					d.Image(helloImage + "@sha512:" + helloDigest)
+				}).DieReleasePtr(),
+			GivenStashedValues: map[reconcilers.StashKey]interface{}{
+				controllers.ImageRefStashKey:         helloImage + "@sha512:" + helloDigest,
+				controllers.ImagePullSecretsStashKey: []corev1.Secret{},
+				controllers.HttpRoundTripperStashKey: registry.Client().Transport,
+			},
+			ExpectResource: parent.
+				SpecDie(func(d *diesourcev1alpha1.ImageRepositorySpecDie) {
+					d.Image(helloImage + "@sha512:" + helloDigest)
+				}).
+				StatusDie(func(d *diesourcev1alpha1.ImageRepositoryStatusDie) {
+					d.ConditionsDie(
+						diesourcev1alpha1.ImageRepositoryConditionImageResolvedBlank.Status(metav1.ConditionFalse).Reason("MalformedDigest").Message(`Image reference "`+helloImage+`@sha512:`+helloDigest+`" is not a valid digest: unsupported digest algorithm: sha512:`+helloDigest),
+						diesourcev1alpha1.ImageRepositoryConditionReadyBlank.Status(metav1.ConditionFalse).Reason("MalformedDigest").Message(`Image reference "`+helloImage+`@sha512:`+helloDigest+`" is not a valid digest: unsupported digest algorithm: sha512:`+helloDigest),
+					)
+				}).DieReleasePtr(),
 		}}
 
 	rts.Run(t, scheme, func(t *testing.T, rtc *rtesting.SubReconcilerTestCase[*sourcev1alpha1.ImageRepository], c reconcilers.Config) reconcilers.SubReconciler[*sourcev1alpha1.ImageRepository] {


### PR DESCRIPTION


Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
ImageRepositoryPullImageSyncReconciler.Sync derived the artifact filename via strings.Split(imageRef, "@sha256:")[1], which panics if imageRef lacks that literal substring. Parse the digest with name.NewDigest instead and mark the ImageResolved condition False on failure rather than crashing the controller.

### Describe testing done for PR

Unit test created