### PR TITLE
Reject path traversal in Maven artifact coordinate fields

### DIFF
--- a/apis/source/v1alpha1/mavenartifact_test.go
+++ b/apis/source/v1alpha1/mavenartifact_test.go
@@ -314,6 +314,103 @@ func TestMavenArtifactValidate(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "timeout"), &metav1.Duration{}, ""),
 			},
 		},
+		{
+			name: "invalid artifactId path traversal",
+			seed: &MavenArtifact{
+				Spec: MavenArtifactSpec{
+					Artifact: MavenArtifactType{
+						GroupId:    "com.example",
+						ArtifactId: "../../../etc/passwd",
+						Version:    "1.0.0",
+					},
+					Repository: Repository{
+						URL: "https://repo1.maven.org/maven2",
+					},
+					Interval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "artifact", "artifactId"), "../../../etc/passwd", `must not contain path separators or ".."`),
+			},
+		},
+		{
+			name: "invalid groupId path traversal",
+			seed: &MavenArtifact{
+				Spec: MavenArtifactSpec{
+					Artifact: MavenArtifactType{
+						GroupId:    "com.example/../../etc",
+						ArtifactId: "my-artifact",
+						Version:    "1.0.0",
+					},
+					Repository: Repository{
+						URL: "https://repo1.maven.org/maven2",
+					},
+					Interval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "artifact", "groupId"), "com.example/../../etc", `must not contain path separators or ".."`),
+			},
+		},
+		{
+			name: "invalid version path traversal",
+			seed: &MavenArtifact{
+				Spec: MavenArtifactSpec{
+					Artifact: MavenArtifactType{
+						GroupId:    "com.example",
+						ArtifactId: "my-artifact",
+						Version:    "../../../../tmp/pwn",
+					},
+					Repository: Repository{
+						URL: "https://repo1.maven.org/maven2",
+					},
+					Interval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "artifact", "version"), "../../../../tmp/pwn", `must not contain path separators or ".."`),
+			},
+		},
+		{
+			name: "invalid type path traversal",
+			seed: &MavenArtifact{
+				Spec: MavenArtifactSpec{
+					Artifact: MavenArtifactType{
+						GroupId:    "com.example",
+						ArtifactId: "my-artifact",
+						Version:    "1.0.0",
+						Type:       "../../etc/passwd",
+					},
+					Repository: Repository{
+						URL: "https://repo1.maven.org/maven2",
+					},
+					Interval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "artifact", "type"), "../../etc/passwd", `must not contain path separators or ".."`),
+			},
+		},
+		{
+			name: "invalid classifier path traversal",
+			seed: &MavenArtifact{
+				Spec: MavenArtifactSpec{
+					Artifact: MavenArtifactType{
+						GroupId:    "com.example",
+						ArtifactId: "my-artifact",
+						Version:    "1.0.0",
+						Classifier: "../../etc/passwd",
+					},
+					Repository: Repository{
+						URL: "https://repo1.maven.org/maven2",
+					},
+					Interval: metav1.Duration{Duration: time.Minute},
+				},
+			},
+			expected: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "artifact", "classifier"), "../../etc/passwd", `must not contain path separators or ".."`),
+			},
+		},
 	}
 
 	for _, c := range tests {

--- a/apis/source/v1alpha1/mavenartifact_validation.go
+++ b/apis/source/v1alpha1/mavenartifact_validation.go
@@ -76,9 +76,13 @@ func (s *MavenArtifactType) validate(fldPath *field.Path) field.ErrorList {
 
 	if s.GroupId == "" {
 		errs = append(errs, field.Required(fldPath.Child("groupId"), ""))
+	} else if containsPathTraversal(s.GroupId) {
+		errs = append(errs, field.Invalid(fldPath.Child("groupId"), s.GroupId, "must not contain path separators or \"..\""))
 	}
 	if s.ArtifactId == "" {
 		errs = append(errs, field.Required(fldPath.Child("artifactId"), ""))
+	} else if containsPathTraversal(s.ArtifactId) {
+		errs = append(errs, field.Invalid(fldPath.Child("artifactId"), s.ArtifactId, "must not contain path separators or \"..\""))
 	}
 
 	if s.Version == "" {
@@ -87,9 +91,26 @@ func (s *MavenArtifactType) validate(fldPath *field.Path) field.ErrorList {
 		strings.HasPrefix(s.Version, "(") {
 		// TODO remove this validation rule when version range is resolvable
 		errs = append(errs, field.Invalid(fldPath.Child("version"), s.Version, ""))
+	} else if containsPathTraversal(s.Version) {
+		errs = append(errs, field.Invalid(fldPath.Child("version"), s.Version, "must not contain path separators or \"..\""))
+	}
+
+	if s.Type != "" && containsPathTraversal(s.Type) {
+		errs = append(errs, field.Invalid(fldPath.Child("type"), s.Type, "must not contain path separators or \"..\""))
+	}
+	if s.Classifier != "" && containsPathTraversal(s.Classifier) {
+		errs = append(errs, field.Invalid(fldPath.Child("classifier"), s.Classifier, "must not contain path separators or \"..\""))
 	}
 
 	return errs
+}
+
+// containsPathTraversal reports whether value contains a path separator or
+// is exactly "..", which would allow it to escape the directory it is
+// combined into when used to build a local filename or a remote request
+// path (e.g. via spec.artifact.{groupId,artifactId,classifier,type,version}).
+func containsPathTraversal(value string) bool {
+	return value == ".." || strings.ContainsAny(value, "/\\")
 }
 
 func (s *Repository) validate(fldPath *field.Path) field.ErrorList {

--- a/controllers/internal.go
+++ b/controllers/internal.go
@@ -5,12 +5,25 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"carvel.dev/imgpkg/pkg/imgpkg/plainimage"
 
 	sourcev1alpha1 "github.com/vmware-tanzu/tanzu-source-controller/apis/source/v1alpha1"
 )
+
+// sanitizeFilename returns an error if name is not a plain, single-segment
+// filename. This guards against path traversal via artifact coordinate
+// fields (groupId/artifactId/classifier/type) or a version string resolved
+// from a remote maven-metadata.xml, either of which may contain attacker
+// controlled "/" or ".." segments.
+func sanitizeFilename(name string) (string, error) {
+	if name == "" || name == "." || name == ".." || name != filepath.Base(name) {
+		return "", fmt.Errorf("resolved filename %q is not a valid filename", name)
+	}
+	return name, nil
+}
 
 type downloadError struct {
 	err            error
@@ -78,6 +91,10 @@ func (r *MavenResolver) processFixedVersion() error {
 	// set artificat download URL
 	r.DownloadURL = fmt.Sprintf("%s/%s/%s/%s", r.RepositoryURL, r.RequestPath, r.ResolvedVersion, r.ResolvedFilename)
 
+	if _, err := sanitizeFilename(r.ResolvedFilename); err != nil {
+		return fmt.Errorf("resolved artifact filename is invalid: %w", err)
+	}
+
 	return nil
 }
 
@@ -123,6 +140,11 @@ func (r *MavenResolver) processLatestVersion(ctx context.Context, client *http.C
 
 	// set artificat download URL
 	r.DownloadURL = fmt.Sprintf("%s/%s/%s/%s", r.RepositoryURL, r.RequestPath, r.ResolvedVersion, r.ResolvedFilename)
+
+	if _, err := sanitizeFilename(r.ResolvedFilename); err != nil {
+		return fmt.Errorf("resolved artifact filename is invalid: %w", err)
+	}
+
 	return nil
 }
 
@@ -153,6 +175,11 @@ func (r *MavenResolver) processSnapshotVersion(ctx context.Context, client *http
 
 	// set artificat download URL
 	r.DownloadURL = fmt.Sprintf("%s/%s/%s/%s", r.RepositoryURL, r.RequestPath, r.Artifact.Version, r.ResolvedFilename)
+
+	if _, err := sanitizeFilename(r.ResolvedFilename); err != nil {
+		return fmt.Errorf("resolved artifact filename is invalid: %w", err)
+	}
+
 	return nil
 }
 
@@ -185,6 +212,11 @@ func (r *MavenResolver) processReleaseVersion(ctx context.Context, client *http.
 
 	// set artifact download URL
 	r.DownloadURL = fmt.Sprintf("%s/%s/%s/%s", r.RepositoryURL, r.RequestPath, r.ResolvedVersion, r.ResolvedFilename)
+
+	if _, err := sanitizeFilename(r.ResolvedFilename); err != nil {
+		return fmt.Errorf("resolved artifact filename is invalid: %w", err)
+	}
+
 	return nil
 }
 

--- a/controllers/internal_test.go
+++ b/controllers/internal_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"reconciler.io/runtime/reconcilers"
+
+	sourcev1alpha1 "github.com/vmware-tanzu/tanzu-source-controller/apis/source/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-source-controller/controllers"
+)
+
+// TestMavenResolverRejectsPathTraversal covers TNZGOV-5941: ArtifactId,
+// Classifier, Type are attacker-controlled CR fields, and the resolved
+// version for RELEASE/LATEST/SNAPSHOT is attacker-controlled via a malicious
+// maven-metadata.xml served by spec.repository.url. Any of these containing
+// "/" or ".." must cause Resolve to return an error rather than yielding a
+// ResolvedFilename usable to escape the artifact directory.
+func TestMavenResolverRejectsPathTraversal(t *testing.T) {
+	tests := []struct {
+		name         string
+		artifact     sourcev1alpha1.MavenArtifactType
+		metadataBody string
+	}{
+		{
+			name: "artifactId path traversal, pinned version",
+			artifact: sourcev1alpha1.MavenArtifactType{
+				GroupId:    "com.example",
+				ArtifactId: "../../../tmp/pwn",
+				Version:    "1.0.0",
+				Type:       "jar",
+			},
+		},
+		{
+			name: "classifier path traversal, pinned version",
+			artifact: sourcev1alpha1.MavenArtifactType{
+				GroupId:    "com.example",
+				ArtifactId: "my-artifact",
+				Version:    "1.0.0",
+				Type:       "jar",
+				Classifier: "../../../tmp/pwn",
+			},
+		},
+		{
+			name: "type path traversal, pinned version",
+			artifact: sourcev1alpha1.MavenArtifactType{
+				GroupId:    "com.example",
+				ArtifactId: "my-artifact",
+				Version:    "1.0.0",
+				Type:       "../../../tmp/pwn",
+			},
+		},
+		{
+			name: "RELEASE resolves to a path traversal value from remote metadata",
+			artifact: sourcev1alpha1.MavenArtifactType{
+				GroupId:    "com.example",
+				ArtifactId: "my-artifact",
+				Version:    "RELEASE",
+				Type:       "jar",
+			},
+			metadataBody: `<metadata><versioning><release>../../../tmp/pwn</release></versioning></metadata>`,
+		},
+		{
+			name: "LATEST resolves to a path traversal value from remote metadata",
+			artifact: sourcev1alpha1.MavenArtifactType{
+				GroupId:    "com.example",
+				ArtifactId: "my-artifact",
+				Version:    "LATEST",
+				Type:       "jar",
+			},
+			metadataBody: `<metadata><versioning><latest>../../../tmp/pwn</latest></versioning></metadata>`,
+		},
+		{
+			name: "SNAPSHOT resolves to a path traversal value from remote metadata",
+			artifact: sourcev1alpha1.MavenArtifactType{
+				GroupId:    "com.example",
+				ArtifactId: "my-artifact",
+				Version:    "1.0.0-SNAPSHOT",
+				Type:       "jar",
+			},
+			metadataBody: `<metadata>
+				<version>1.0.0-SNAPSHOT</version>
+				<versioning>
+					<snapshot><timestamp>../../../tmp</timestamp><buildNumber>pwn</buildNumber></snapshot>
+					<snapshotVersions>
+						<snapshotVersion><extension>jar</extension><value>1.0.0-../../../tmp-pwn</value></snapshotVersion>
+					</snapshotVersions>
+				</versioning>
+			</metadata>`,
+		},
+	}
+
+	for _, c := range tests {
+		t.Run(c.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(c.metadataBody))
+			}))
+			defer server.Close()
+
+			resolver := controllers.MavenResolver{
+				Artifact:      c.artifact,
+				RepositoryURL: server.URL,
+				RequestPath:   "com/example/my-artifact",
+			}
+
+			ctx := reconcilers.WithStash(context.Background())
+			err := resolver.Resolve(ctx, server.Client())
+			if err == nil {
+				t.Fatalf("expected Resolve to return an error, but got resolved filename %q", resolver.ResolvedFilename)
+			}
+			if !strings.Contains(err.Error(), "not a valid filename") {
+				t.Fatalf("expected a resolved-filename validation error, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`MavenResolver` built the local artifact filename via `fmt.Sprintf("%s-%s.%s", ArtifactId, Version, Type)` (optionally with `Classifier`) with no sanitization. Two independent inputs feed this:

- `spec.artifact.{artifactId,classifier,type}` are supplied directly on the CR and were not validated by the admission webhook beyond non-empty checks.
- For `RELEASE`/`LATEST`/`*-SNAPSHOT`, the resolved version comes verbatim from a remote `maven-metadata.xml` served by whatever host `spec.repository.url` points at.

Either source containing `../` segments lets the resulting filename escape the intended artifact/cache directory when passed to `os.Create`/`os.WriteFile` via `path.Join`, since `path.Join` resolves `..` upward rather than rejecting it. This allows a file write with attacker-controlled path and content on the controller pod.

## Fix

- Sanitize the resolved filename at its single source — right after `ResolvedFilename` is set in each `MavenResolver.process*Version` method (`internal.go`) — rejecting anything that isn't a plain, single-segment filename. This covers both downstream file-write sinks and the remote-metadata-controlled case, which an admission webhook can't see.
- Added defense-in-depth admission webhook validation rejecting path separators / `..` in the directly user-supplied `groupId`/`artifactId`/`version`/`type`/`classifier` fields, for immediate feedback at CR creation time.

## Test plan

- [x] `make test` passes (includes `manifests`/`generate`/`fmt`/`vet` + full test suite)
- [x] New `controllers/internal_test.go`: `MavenResolver.Resolve` rejects traversal via `artifactId`/`classifier`/`type` directly, and via malicious `RELEASE`/`LATEST`/`SNAPSHOT` metadata responses
- [x] Extended `TestMavenArtifactValidate` in `apis/source/v1alpha1/mavenartifact_test.go` with 5 new webhook validation cases
- [x] `git diff --exit-code` after `make tidy tools dist` produces no diff (matches CI's generation check)