### PR TITLE
Reject zip-slip paths during Maven artifact extraction

### DIFF
--- a/controllers/mavenartifact_controller.go
+++ b/controllers/mavenartifact_controller.go
@@ -680,12 +680,31 @@ func extractArchive(parentDir string, pathToJarFile string) (string, error) {
 	defer openedFile.Close()
 
 	for _, file := range openedFile.File {
-		filePath := filepath.Join(fileDestinationFolder, file.Name)
+		filePath, err := safeArchiveEntryPath(fileDestinationFolder, file.Name)
+		if err != nil {
+			return "", err
+		}
 		if err = extractFile(file, filePath); err != nil {
 			return "", err
 		}
 	}
 	return fileDestinationFolder, err
+}
+
+// safeArchiveEntryPath joins name onto destDir and rejects the result unless
+// it stays within destDir. Archive entry names are attacker controlled (the
+// archive is downloaded from a URL built from unvalidated MavenArtifact CR
+// fields), so an entry like "../../etc/evil" or an absolute path must not be
+// allowed to escape destDir (zip-slip).
+func safeArchiveEntryPath(destDir, name string) (string, error) {
+	if filepath.IsAbs(name) {
+		return "", fmt.Errorf("archive entry %q has an absolute path", name)
+	}
+	joined := filepath.Join(destDir, name)
+	if joined != destDir && !strings.HasPrefix(joined, destDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry %q escapes destination directory %q", name, destDir)
+	}
+	return joined, nil
 }
 
 func extractFile(file *zip.File, filePath string) error {

--- a/controllers/zip_extract_test.go
+++ b/controllers/zip_extract_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"archive/zip"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExtractArchiveRejectsZipSlip covers TNZ-103874: zip/jar entry names are
+// attacker controlled (the archive is downloaded from a URL built from
+// unvalidated MavenArtifact CR fields), so extractArchive must reject any
+// entry whose name would resolve outside the destination directory rather
+// than writing it there (zip-slip).
+func TestExtractArchiveRejectsZipSlip(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryName string
+	}{
+		{
+			name:      "parent directory traversal",
+			entryName: "../../evil.txt",
+		},
+		{
+			name:      "deep parent directory traversal",
+			entryName: "../../../etc/evil.txt",
+		},
+		{
+			name:      "absolute path",
+			entryName: "/tmp/evil.txt",
+		},
+		{
+			name:      "directory entry with traversal",
+			entryName: "../evil-dir/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parentDir := t.TempDir()
+			zipPath := writeTestZip(t, parentDir, tc.entryName, "pwned")
+
+			if _, err := extractArchive(parentDir, zipPath); err == nil {
+				t.Fatalf("expected extractArchive to reject entry %q, got nil error", tc.entryName)
+			}
+
+			escaped := filepath.Join(parentDir, filepath.Clean(tc.entryName))
+			if _, err := os.Stat(escaped); !os.IsNotExist(err) {
+				t.Fatalf("archive entry %q escaped destination directory: %q exists", tc.entryName, escaped)
+			}
+		})
+	}
+}
+
+// TestExtractArchiveWellBehavedEntries is a regression guard: normal
+// relative entries must still extract successfully after the zip-slip fix.
+func TestExtractArchiveWellBehavedEntries(t *testing.T) {
+	parentDir := t.TempDir()
+	zipPath := writeTestZipMulti(t, parentDir, []zipEntry{
+		{name: "META-INF/"},
+		{name: "META-INF/MANIFEST.MF", contents: "Manifest-Version: 1.0\n"},
+		{name: "com/"},
+		{name: "com/example/"},
+		{name: "com/example/Foo.class", contents: "fake-class-bytes"},
+	})
+
+	extractedDir, err := extractArchive(parentDir, zipPath)
+	if err != nil {
+		t.Fatalf("unexpected error extracting well-behaved archive: %v", err)
+	}
+
+	for _, entry := range []string{"META-INF/MANIFEST.MF", "com/example/Foo.class"} {
+		if _, err := os.Stat(filepath.Join(extractedDir, entry)); err != nil {
+			t.Fatalf("expected extracted file %q: %v", entry, err)
+		}
+	}
+}
+
+type zipEntry struct {
+	name     string
+	contents string
+}
+
+func writeTestZip(t *testing.T, dir, entryName, contents string) string {
+	t.Helper()
+	return writeTestZipMulti(t, dir, []zipEntry{{name: entryName, contents: contents}})
+}
+
+// writeTestZipMulti writes entries to a zip file in the given order. Order
+// matters: extractArchive processes entries in zip order and does not create
+// parent directories for a file entry, so a directory entry must precede any
+// file entries nested under it (as real jar/zip archives do).
+func writeTestZipMulti(t *testing.T, dir string, entries []zipEntry) string {
+	t.Helper()
+
+	zipPath := path.Join(dir, "test.zip")
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("failed to create zip file: %v", err)
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	for _, entry := range entries {
+		w, err := zipWriter.Create(entry.name)
+		if err != nil {
+			t.Fatalf("failed to create zip entry %q: %v", entry.name, err)
+		}
+		// A directory entry (name ends in "/") has no content.
+		if strings.HasSuffix(entry.name, "/") {
+			continue
+		}
+		if _, err := w.Write([]byte(entry.contents)); err != nil {
+			t.Fatalf("failed to write zip entry %q: %v", entry.name, err)
+		}
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+
+	return zipPath
+}


### PR DESCRIPTION
## Summary
- `extractArchive()` joined zip/jar entry names directly onto the extraction directory with no `..` containment check. The archive is downloaded from a URL built entirely from unvalidated `MavenArtifact` CR fields (`spec.repository.url`, `spec.artifact.*`), and the SHA-1 integrity check fetches its expected checksum from that same attacker-controlled host, so a malicious repository could serve an archive with an entry like `../../../artifacts/other-ns/victim/x.tar.gz` and write arbitrary files outside the intended extraction directory.
- Added `safeArchiveEntryPath()` to reject absolute entry names and any entry whose joined/cleaned path would escape the destination directory, called before `extractFile` ever touches the filesystem.

## Test plan
- [x] Added `controllers/zip_extract_test.go` covering parent-directory traversal, deep traversal, absolute paths, and malicious directory entries — all rejected with no file written outside the destination directory.
- [x] Added a regression test confirming well-behaved archives (normal relative entries, nested directories) still extract successfully.
- [x] `make test` passes (full suite, including manifest/generate diff check).