### PR TITLE
Reject cross-host/scheme HTTP redirects in Maven artifact client

### DIFF
--- a/controllers/mavenartifact_controller.go
+++ b/controllers/mavenartifact_controller.go
@@ -99,6 +99,29 @@ func MavenArtifactReconciler(c reconcilers.Config, httpRootDir, httpHost string,
 	}
 }
 
+// maxRedirects matches the hop cap Go's http.Client applies by default;
+// setting CheckRedirect disables that default, so it must be replicated here.
+const maxRedirects = 10
+
+// sameHostRedirectPolicy is an http.Client.CheckRedirect func that pins every
+// redirect hop to the same scheme and host as the originally requested URL.
+// The initial repository host is operator-configured and may legitimately be
+// a private/internal address, but nothing the repository returns in a
+// redirect Location should be trusted to point anywhere else (e.g. cloud
+// IMDS) — see TNZGOV-13098.
+func sameHostRedirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+
+	orig := via[0].URL
+	if req.URL.Scheme != orig.Scheme || req.URL.Host != orig.Host {
+		return fmt.Errorf("redirect from %q to %q crosses origin scheme/host, which is not allowed", orig, req.URL)
+	}
+
+	return nil
+}
+
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 func MavenArtifactSecretsSyncReconciler(certs []Cert) reconcilers.SubReconciler[*sourcev1alpha1.MavenArtifact] {
@@ -134,7 +157,7 @@ func MavenArtifactSecretsSyncReconciler(certs []Cert) reconcilers.SubReconciler[
 			if err != nil {
 				return err
 			}
-			client := &http.Client{Transport: t}
+			client := &http.Client{Transport: t, CheckRedirect: sameHostRedirectPolicy}
 			stashHttpClient(ctx, client)
 			return nil
 		},

--- a/controllers/mavenartifact_controller_test.go
+++ b/controllers/mavenartifact_controller_test.go
@@ -1949,9 +1949,25 @@ func TestMavenArtifactReconciler(t *testing.T) {
 	fileNameWithoutType := "8fdea0bf0e6441c8717853230a270e4ed51cd77a"
 	checksum := "6271d8d39c1936f8e0b25c8b2d43fe671f7de1f8"
 
+	// TNZGOV-13098: artifact IDs used to prove the repository host cannot use an
+	// HTTP redirect to send the client's follow-up request to a different host.
+	redirectCrossHostArtifactId := "redirect-crosshost"
+	redirectCrossHostFileName := fmt.Sprintf("%s-%s.jar", redirectCrossHostArtifactId, latestVersion)
+	redirectSameHostArtifactId := "redirect-samehost"
+	redirectSameHostFileName := fmt.Sprintf("%s-%s.jar", redirectSameHostArtifactId, latestVersion)
+
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(sourcev1alpha1.AddToScheme(scheme))
+
+	// ssrfTargetServer stands in for an attacker-reachable internal endpoint (e.g.
+	// cloud IMDS). It must never be dialed by the reconciler: a cross-host redirect
+	// from tlsServer to here must be rejected before the request is ever sent.
+	ssrfTargetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("attacker-controlled-response"))
+	}))
+	defer ssrfTargetServer.Close()
 
 	tlsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		func(w http.ResponseWriter, r *http.Request) {
@@ -1977,12 +1993,32 @@ func TestMavenArtifactReconciler(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(checksum))
 
+			} else if r.URL.Path == fmt.Sprintf("/ca-releases/%v/%v/%v/%v.sha1", groupId, redirectCrossHostArtifactId, latestVersion, redirectCrossHostFileName) {
+				// checksum lookup succeeds normally; the attack is in the artifact download redirect below.
+				// fileNameWithoutType is the sha1 of the raw jar fixture (see the helloworld ".sha1" branch above).
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(fileNameWithoutType))
+			} else if r.URL.Path == fmt.Sprintf("/ca-releases/%v/%v/%v/%v", groupId, redirectCrossHostArtifactId, latestVersion, redirectCrossHostFileName) {
+				w.Header().Set("Location", ssrfTargetServer.URL+"/anything")
+				w.WriteHeader(http.StatusFound)
+			} else if r.URL.Path == fmt.Sprintf("/ca-releases/%v/%v/%v/%v.sha1", groupId, redirectSameHostArtifactId, latestVersion, redirectSameHostFileName) {
+				// must match the sha1 of the raw jar content served after following the same-host redirect below.
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(fileNameWithoutType))
+			} else if r.URL.Path == fmt.Sprintf("/ca-releases/%v/%v/%v/%v", groupId, redirectSameHostArtifactId, latestVersion, redirectSameHostFileName) {
+				w.Header().Set("Location", fmt.Sprintf("/ca-releases/%v/%v/%v/%v", groupId, artifactId, latestVersion, fileName))
+				w.WriteHeader(http.StatusFound)
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 			}
 		}(w, r)
 	}))
 	defer tlsServer.Close()
+
+	// crossHostDownloadURL/ssrfRedirectTarget are used both by the redirect handler above and to
+	// assert the exact rejection message sameHostRedirectPolicy produces.
+	crossHostDownloadURL := fmt.Sprintf("%s/ca-releases/%s/%s/%s/%s", tlsServer.URL, groupId, redirectCrossHostArtifactId, latestVersion, redirectCrossHostFileName)
+	ssrfRedirectTarget := ssrfTargetServer.URL + "/anything"
 
 	artifactRootDir, err := os.MkdirTemp(os.TempDir(), "artifacts.*")
 	utilruntime.Must(err)
@@ -2050,6 +2086,130 @@ func TestMavenArtifactReconciler(t *testing.T) {
 						d.ConditionsDie(
 							diesourcev1alpha1.MavenArtifactConditionAvailableBlank.Status(metav1.ConditionTrue).Reason("Available"),
 							diesourcev1alpha1.MavenArtifactConditionVersionResolvedBlank.Status(metav1.ConditionTrue).Reason("Resolved").Messagef(`Resolved version %q for artifact "%s/%s/%s/%s/%s-%s.jar"`, latestVersion, tlsServer.URL+"/ca-releases", groupId, artifactId, latestVersion, artifactId, latestVersion),
+							diesourcev1alpha1.MavenArtifactConditionReadyBlank.Status(metav1.ConditionTrue).Reason("Ready"),
+						)
+					}),
+			},
+
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "source.apps.tanzu.vmware.com",
+					Kind:      "MavenArtifact",
+					Namespace: parent.GetNamespace(),
+					Name:      parent.GetName(),
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["source.apps.tanzu.vmware.com/finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(parent, scheme, corev1.EventTypeNormal, "FinalizerPatched", "Patched finalizer %q", "source.apps.tanzu.vmware.com/finalizer"),
+				rtesting.NewEvent(parent, scheme, corev1.EventTypeNormal, "StatusUpdated", `Updated status`),
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(certSecret, parent, scheme),
+			},
+			ExpectedResult: reconcile.Result{},
+		},
+		"cross-host artifact redirect is rejected": {
+			Request: request,
+			StatusSubResourceTypes: []client.Object{
+				&sourcev1alpha1.MavenArtifact{},
+			},
+			GivenObjects: []client.Object{
+				parent.
+					SpecDie(func(d *diesourcev1alpha1.MavenArtifactSpecDie) {
+						d.MavenArtifactDie(func(d *diesourcev1alpha1.MavenArtifactTypeDie) {
+							d.Type("jar")
+							d.ArtifactId(redirectCrossHostArtifactId)
+							d.GroupId(groupId)
+							d.Version(latestVersion)
+						})
+						d.RepositoryDie(func(d *diesourcev1alpha1.RepositoryDie) {
+							d.URL(tlsServer.URL + "/ca-releases")
+							d.SecretRef(corev1.LocalObjectReference{Name: "cert-secret-ref"})
+						})
+						d.Interval(metav1.Duration{Duration: 5 * time.Minute})
+						d.Timeout(&metav1.Duration{Duration: 5 * time.Minute})
+					}),
+				certSecret,
+			},
+
+			ExpectStatusUpdates: []client.Object{
+				parent.
+					StatusDie(func(d *diesourcev1alpha1.MavenArtifactStatusDie) {
+						d.ObservedGeneration(1)
+						d.ConditionsDie(
+							diesourcev1alpha1.MavenArtifactConditionAvailableBlank.Status(metav1.ConditionFalse).Reason("DownloadError").
+								Messagef(`Error downloading Maven artifact file %q: %s download error Get %q: redirect from %q to %q crosses origin scheme/host, which is not allowed`,
+									redirectCrossHostArtifactId, crossHostDownloadURL, ssrfRedirectTarget, crossHostDownloadURL, ssrfRedirectTarget),
+							diesourcev1alpha1.MavenArtifactConditionVersionResolvedBlank.Status(metav1.ConditionTrue).Reason("Resolved").
+								Messagef(`Resolved version %q for artifact "%s/%s/%s/%s/%s"`, latestVersion, tlsServer.URL+"/ca-releases", groupId, redirectCrossHostArtifactId, latestVersion, redirectCrossHostFileName),
+							diesourcev1alpha1.MavenArtifactConditionReadyBlank.Status(metav1.ConditionFalse).Reason("DownloadError").
+								Messagef(`Error downloading Maven artifact file %q: %s download error Get %q: redirect from %q to %q crosses origin scheme/host, which is not allowed`,
+									redirectCrossHostArtifactId, crossHostDownloadURL, ssrfRedirectTarget, crossHostDownloadURL, ssrfRedirectTarget),
+						)
+					}),
+			},
+
+			ExpectPatches: []rtesting.PatchRef{
+				{
+					Group:     "source.apps.tanzu.vmware.com",
+					Kind:      "MavenArtifact",
+					Namespace: parent.GetNamespace(),
+					Name:      parent.GetName(),
+					PatchType: types.MergePatchType,
+					Patch:     []byte(`{"metadata":{"finalizers":["source.apps.tanzu.vmware.com/finalizer"],"resourceVersion":"999"}}`),
+				},
+			},
+			ExpectEvents: []rtesting.Event{
+				rtesting.NewEvent(parent, scheme, corev1.EventTypeNormal, "FinalizerPatched", "Patched finalizer %q", "source.apps.tanzu.vmware.com/finalizer"),
+				rtesting.NewEvent(parent, scheme, corev1.EventTypeNormal, "StatusUpdated", `Updated status`),
+			},
+			ExpectTracks: []rtesting.TrackRequest{
+				rtesting.NewTrackRequest(certSecret, parent, scheme),
+			},
+			ExpectedResult: reconcile.Result{},
+		},
+		"same-host artifact redirect still succeeds": {
+			Request: request,
+			StatusSubResourceTypes: []client.Object{
+				&sourcev1alpha1.MavenArtifact{},
+			},
+			GivenObjects: []client.Object{
+				parent.
+					SpecDie(func(d *diesourcev1alpha1.MavenArtifactSpecDie) {
+						d.MavenArtifactDie(func(d *diesourcev1alpha1.MavenArtifactTypeDie) {
+							d.Type("jar")
+							d.ArtifactId(redirectSameHostArtifactId)
+							d.GroupId(groupId)
+							d.Version(latestVersion)
+						})
+						d.RepositoryDie(func(d *diesourcev1alpha1.RepositoryDie) {
+							d.URL(tlsServer.URL + "/ca-releases")
+							d.SecretRef(corev1.LocalObjectReference{Name: "cert-secret-ref"})
+						})
+						d.Interval(metav1.Duration{Duration: 5 * time.Minute})
+						d.Timeout(&metav1.Duration{Duration: 5 * time.Minute})
+					}),
+				certSecret,
+			},
+
+			ExpectStatusUpdates: []client.Object{
+				parent.
+					StatusDie(func(d *diesourcev1alpha1.MavenArtifactStatusDie) {
+						d.ArtifactDie(func(d *diesourcev1alpha1.ArtifactDie) {
+							d.Revision(redirectSameHostFileName)
+							d.Path(fmt.Sprintf("mavenartifact/%s/%s/%s.tar.gz", namespace, name, fileNameWithoutType))
+							d.URL(fmt.Sprintf("http://artifact.example/mavenartifact/%s/%s/%s.tar.gz", namespace, name, fileNameWithoutType))
+							d.LastUpdateTime(now())
+							d.Checksum(checksum)
+						})
+						d.URL(fmt.Sprintf("http://artifact.example/mavenartifact/%s/%s/%s.tar.gz", namespace, name, fileNameWithoutType))
+						d.ObservedGeneration(1)
+						d.ConditionsDie(
+							diesourcev1alpha1.MavenArtifactConditionAvailableBlank.Status(metav1.ConditionTrue).Reason("Available"),
+							diesourcev1alpha1.MavenArtifactConditionVersionResolvedBlank.Status(metav1.ConditionTrue).Reason("Resolved").
+								Messagef(`Resolved version %q for artifact "%s/%s/%s/%s/%s"`, latestVersion, tlsServer.URL+"/ca-releases", groupId, redirectSameHostArtifactId, latestVersion, redirectSameHostFileName),
 							diesourcev1alpha1.MavenArtifactConditionReadyBlank.Status(metav1.ConditionTrue).Reason("Ready"),
 						)
 					}),

--- a/controllers/redirect_policy_test.go
+++ b/controllers/redirect_policy_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// TestSameHostRedirectPolicy covers TNZGOV-13098: the shared http.Client used
+// for Maven repository requests has no CheckRedirect, so it will transparently
+// follow a redirect to any host/scheme (e.g. cloud IMDS). sameHostRedirectPolicy
+// must pin every redirect to the same scheme+host as the original request.
+func TestSameHostRedirectPolicy(t *testing.T) {
+	mustParse := func(t *testing.T, raw string) *url.URL {
+		t.Helper()
+		u, err := url.Parse(raw)
+		if err != nil {
+			t.Fatalf("failed to parse url %q: %v", raw, err)
+		}
+		return u
+	}
+
+	req := func(t *testing.T, raw string) *http.Request {
+		t.Helper()
+		return &http.Request{URL: mustParse(t, raw)}
+	}
+
+	tests := []struct {
+		name    string
+		via     []string
+		next    string
+		wantErr bool
+	}{
+		{
+			name:    "same host and scheme",
+			via:     []string{"https://repo.example.com/maven-metadata.xml"},
+			next:    "https://repo.example.com/redirected/maven-metadata.xml",
+			wantErr: false,
+		},
+		{
+			name:    "same host, different path and query",
+			via:     []string{"https://repo.example.com/a/b?x=1"},
+			next:    "https://repo.example.com/c/d?y=2",
+			wantErr: false,
+		},
+		{
+			name:    "cross-host redirect rejected",
+			via:     []string{"https://repo.example.com/maven-metadata.xml"},
+			next:    "https://169.254.169.254/latest/meta-data/iam/security-credentials/",
+			wantErr: true,
+		},
+		{
+			name:    "scheme downgrade rejected",
+			via:     []string{"https://repo.example.com/maven-metadata.xml"},
+			next:    "http://repo.example.com/maven-metadata.xml",
+			wantErr: true,
+		},
+		{
+			name: "too many redirects rejected",
+			via: func() []string {
+				via := make([]string, 10)
+				for i := range via {
+					via[i] = "https://repo.example.com/hop"
+				}
+				return via
+			}(),
+			next:    "https://repo.example.com/hop",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			via := make([]*http.Request, len(tc.via))
+			for i, raw := range tc.via {
+				via[i] = req(t, raw)
+			}
+
+			err := sameHostRedirectPolicy(req(t, tc.next), via)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error redirecting to %q, got nil", tc.next)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error redirecting to %q, got: %v", tc.next, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- The shared `http.Client` used for all Maven-repository requests had no `CheckRedirect`, so Go's default behavior applied: follow up to 10 redirects across any host or scheme. The only URL validation (scheme must be `https`) ran once against the operator-configured repository URL and was never re-applied to a redirect `Location` header.
- A malicious or compromised repository could respond to a metadata/checksum/artifact request with a redirect to an internal endpoint (e.g. cloud instance metadata), and the controller would transparently follow it, download the body, and potentially publish it as the resolved artifact.
- Adds `sameHostRedirectPolicy`, an `http.Client.CheckRedirect` implementation that pins every redirect hop to the same scheme and host as the originally requested URL, and wires it into the client built by `MavenArtifactSecretsSyncReconciler`. The initial repository host is still operator-configured and may legitimately be a private/internal address; this only prevents the repository from redirecting the client elsewhere. Setting `CheckRedirect` also disables Go's built-in 10-redirect cap, so that limit is replicated explicitly.

## Test plan
- [x] `go test ./controllers/... -run TestSameHostRedirectPolicy -v` — unit tests for the redirect policy (same-host/scheme, cross-host, scheme downgrade, too-many-redirects, same-host different path)
- [x] `go test ./controllers/... -run TestMavenArtifactReconciler -v` — end-to-end cases proving a cross-host redirect is rejected and a same-host redirect to a different path still succeeds
- [x] `make test` — full suite, no diff from `manifests`/`generate`