### PR TITLE
Set read/idle timeouts on the artifact HTTP server

### DIFF
--- a/server/artifact.go
+++ b/server/artifact.go
@@ -20,6 +20,13 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
+)
+
+const (
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 30 * time.Second
+	idleTimeout       = 120 * time.Second
 )
 
 func New(addr string, dir string) *server {
@@ -34,20 +41,31 @@ type server struct {
 	Dir  string
 }
 
+// newHTTPServer builds the http.Server used to serve artifacts. WriteTimeout
+// is deliberately left unset: it bounds the entire response write, and
+// artifacts can be large enough that a fixed cap would truncate legitimate
+// downloads over slow connections.
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		IdleTimeout:       idleTimeout,
+	}
+}
+
 func (s *server) Start(ctx context.Context) error {
 	directoryHandler := http.FileServer(http.Dir(s.Dir))
-	server := http.Server{
-		Addr: s.Addr,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasSuffix(r.URL.Path, "/") {
-				// deactivate directory listings
-				// TODO deactivate redirects for directories `dir` -> `dir/`
-				http.NotFound(w, r)
-				return
-			}
-			directoryHandler.ServeHTTP(w, r)
-		}),
-	}
+	server := newHTTPServer(s.Addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/") {
+			// deactivate directory listings
+			// TODO deactivate redirects for directories `dir` -> `dir/`
+			http.NotFound(w, r)
+			return
+		}
+		directoryHandler.ServeHTTP(w, r)
+	}))
 
 	// shutdown server when the context closes
 	go func() {

--- a/server/artifact_test.go
+++ b/server/artifact_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 VMware, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServer_SetsTimeouts(t *testing.T) {
+	s := newHTTPServer("127.0.0.1:0", http.NewServeMux())
+
+	if s.ReadHeaderTimeout != readHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", s.ReadHeaderTimeout, readHeaderTimeout)
+	}
+	if s.ReadTimeout != readTimeout {
+		t.Errorf("ReadTimeout = %v, want %v", s.ReadTimeout, readTimeout)
+	}
+	if s.IdleTimeout != idleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", s.IdleTimeout, idleTimeout)
+	}
+	if s.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %v, want 0 (unset, so large artifact downloads aren't truncated)", s.WriteTimeout)
+	}
+}
+
+func TestStart_ServesFilesAndRejectsDirectoryListing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "artifact.tar.gz"), []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := lis.Addr().String()
+	lis.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- New(addr, dir).Start(ctx) }()
+
+	baseURL := "http://" + addr
+	var resp *http.Response
+	for range 50 {
+		resp, err = http.Get(baseURL + "/artifact.tar.gz")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("GET file: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET file status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	resp, err = http.Get(baseURL + "/")
+	if err != nil {
+		t.Fatalf("GET directory: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET directory status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil && err != http.ErrServerClosed {
+		t.Errorf("Start() returned unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
The artifact server's http.Server had no ReadHeaderTimeout, ReadTimeout, or IdleTimeout, leaving it exposed to slow-client resource exhaustion (e.g. Slowloris-style attacks holding connections open indefinitely) since it's exposed cluster-wide with no fronting proxy.

Adds a 10s header timeout, 30s read timeout, and 120s idle timeout. WriteTimeout is deliberately left unset since it bounds the entire response write and this server can serve large .tar.gz artifacts -- a fixed cap would truncate legitimate downloads over slow connections.

Test plan:
- go test ./server/... - new tests assert the configured timeouts, and verify the server still serves files and rejects directory listings correctly.
- make test - full suite passes, no regressions.
- make manifests generate dist - no diff (no API/type changes).

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it


### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

