### PR TITLE
ci: update release job to fix set-output deprecation warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -548,9 +548,10 @@ jobs:
       with:
         name: source-controller-bundle.tar
     - name: Rename asset
-      run: mv source-controller-bundle.tar source-controller-bundle-${{ steps.get_version.outputs.VERSION }}.tar
+      run: mv source-controller-bundle.tar "source-controller-bundle-${VERSION}.tar"
+      env:
+        VERSION: ${{ steps.get_version.outputs.VERSION }}
     - name: Draft release
-      id: create_release
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -542,26 +542,19 @@ jobs:
     steps:
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-    - name: Draft release
-      id: create_release
-      uses: actions/create-release@v1.1.4
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ steps.get_version.outputs.VERSION }}
-        draft: true
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Download staged Source Controller build
       uses: actions/download-artifact@v8
       with:
         name: source-controller-bundle.tar
-    - name: Upload Source Controller release
-      uses: actions/upload-release-asset@v1.0.2
+    - name: Rename asset
+      run: mv source-controller-bundle.tar source-controller-bundle-${{ steps.get_version.outputs.VERSION }}.tar
+    - name: Draft release
+      id: create_release
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: source-controller-bundle.tar
-        asset_name: source-controller-bundle-${{ steps.get_version.outputs.VERSION }}.tar
-        asset_content_type: application/x-tar
+        name: Release ${{ steps.get_version.outputs.VERSION }}
+        draft: true
+        files: source-controller-bundle-${{ steps.get_version.outputs.VERSION }}.tar


### PR DESCRIPTION
## Summary
- Updates the version extraction step to use `$GITHUB_OUTPUT` instead of the deprecated `set-output` syntax.
- Replaces the deprecated and archived `actions/create-release` and `actions/upload-release-asset` (which internally triggered the warnings) with the active community-standard `softprops/action-gh-release@v2`.
- Validated `.github/workflows/ci.yaml` formatting with `yq`.